### PR TITLE
Add Chat button on Community screen

### DIFF
--- a/app/community.tsx
+++ b/app/community.tsx
@@ -981,14 +981,27 @@ export default function CommunityScreen() {
                 subtitle="Teile und entdecke Erfahrungen" 
               />
               
-              <TouchableOpacity 
+              <TouchableOpacity
+                style={styles.chatButton}
+                onPress={() =>
+                  router.push({ pathname: '/notifications', params: { tab: 'messages' } } as any)
+                }
+              >
+                <IconSymbol
+                  name="bubble.left.and.bubble.right.fill"
+                  size={24}
+                  color={theme.tabIconDefault}
+                />
+              </TouchableOpacity>
+
+              <TouchableOpacity
                 style={styles.bellButton}
                 onPress={() => router.push('/notifications' as any)}
               >
-                <IconSymbol 
-                  name="bell.fill" 
-                  size={24} 
-                  color={theme.tabIconDefault} 
+                <IconSymbol
+                  name="bell.fill"
+                  size={24}
+                  color={theme.tabIconDefault}
                 />
                 <NotificationBadge refreshTrigger={refreshNotificationBadge} />
               </TouchableOpacity>
@@ -1279,6 +1292,13 @@ const styles = StyleSheet.create({
   overlayContainer: {
     width: '100%',
     position: 'relative',
+  },
+  chatButton: {
+    position: 'absolute',
+    top: 16,
+    right: 56,
+    padding: 8,
+    zIndex: 10,
   },
   bellButton: {
     position: 'absolute',

--- a/app/notifications.tsx
+++ b/app/notifications.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { StyleSheet, View, TouchableOpacity, FlatList, ActivityIndicator, Text, SafeAreaView, RefreshControl } from 'react-native';
-import { Stack, router } from 'expo-router';
+import { Stack, router, useLocalSearchParams } from 'expo-router';
 import { ThemedView } from '@/components/ThemedView';
 import { ThemedText } from '@/components/ThemedText';
 import { ThemedBackground } from '@/components/ThemedBackground';
@@ -35,11 +35,26 @@ const TABS = {
 };
 
 export default function NotificationsScreen() {
+  const { tab } = useLocalSearchParams();
   const colorScheme = useColorScheme() ?? 'light';
   const theme = Colors[colorScheme];
   const { user } = useAuth();
 
-  const [activeTab, setActiveTab] = useState(TABS.MESSAGES);
+  const initialTab = Array.isArray(tab) ? tab[0] : tab;
+  const [activeTab, setActiveTab] = useState(
+    initialTab === 'activity'
+      ? TABS.ACTIVITY
+      : initialTab === 'comments'
+      ? TABS.COMMENTS
+      : TABS.MESSAGES
+  );
+
+  // Aktualisiere den aktiven Tab, wenn sich der Query-Parameter ändert
+  useEffect(() => {
+    if (initialTab === 'activity') setActiveTab(TABS.ACTIVITY);
+    else if (initialTab === 'comments') setActiveTab(TABS.COMMENTS);
+    else if (initialTab === 'messages') setActiveTab(TABS.MESSAGES);
+  }, [initialTab]);
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [messages, setMessages] = useState<DirectMessage[]>([]);
   const [loading, setLoading] = useState(true);

--- a/eas-update-chat.sh
+++ b/eas-update-chat.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Script zum Veröffentlichen eines EAS Updates für die neue Chat-Funktion
+
+# Prüfe, ob die EAS CLI installiert ist
+if ! command -v eas &> /dev/null
+then
+    echo "EAS CLI ist nicht installiert. Installiere..."
+    npm install -g eas-cli
+fi
+
+# Bei EAS anmelden, falls nicht bereits geschehen
+eas whoami || eas login
+
+# EAS Update für alle Plattformen erstellen
+echo "Erstelle EAS Update für Chat-Button..."
+eas update --auto --message "Feature: Chat-Button in Community"
+
+echo "EAS Update wurde erstellt.\nPrüfe den Status mit 'eas update:list'"

--- a/eas-update-instructions.md
+++ b/eas-update-instructions.md
@@ -63,11 +63,21 @@ Nach den Änderungen an der Synchronisierungsfunktionalität für die Alltag-Ein
 
 5. **Überprüfen Sie den Update-Status**
 
-   Nach dem Erstellen des Updates können Sie den Status in der Expo-Webkonsole überprüfen oder mit dem folgenden Befehl:
+Nach dem Erstellen des Updates können Sie den Status in der Expo-Webkonsole überprüfen oder mit dem folgenden Befehl:
 
-   ```bash
-   eas update:list
-   ```
+```bash
+eas update:list
+```
+
+## Chat-Button Update
+
+Um die neue Chat-Funktion schnell zu testen, führen Sie einfach das Skript
+`eas-update-chat.sh` aus:
+
+```bash
+./eas-update-chat.sh
+```
+
 
 ## Testen des Updates
 


### PR DESCRIPTION
## Summary
- add a Chat button to Community screen
- open the Notifications screen (Messages tab) when pressed
- allow Notifications screen to read `tab` query param
- add script to trigger `eas update --auto`

## Testing
- `npm test` *(fails: jest not found)*