### PR TITLE
Add unified care entries table

### DIFF
--- a/app/(tabs)/daily_old.tsx
+++ b/app/(tabs)/daily_old.tsx
@@ -7,7 +7,7 @@ import { useColorScheme } from '@/hooks/useColorScheme';
 import { useAuth } from '@/contexts/AuthContext';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { ThemedBackground } from '@/components/ThemedBackground';
-import { getDailyEntries, saveDailyEntry, deleteDailyEntry, DailyEntry } from '@/lib/baby';
+import { getCareEntries, saveCareEntry, deleteCareEntry, CareEntry } from '@/lib/care';
 import DateTimePicker from '@react-native-community/datetimepicker';
 import ActivitySelector from '@/components/ActivitySelector';
 import ActivityInputModal from '@/components/ActivityInputModal';
@@ -28,7 +28,7 @@ export default function DailyOldScreen() {
   const { user } = useAuth();
   const router = useRouter();
 
-  const [entries, setEntries] = useState<DailyEntry[]>([]);
+  const [entries, setEntries] = useState<CareEntry[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date());
@@ -141,7 +141,7 @@ export default function DailyOldScreen() {
       console.log('Loading entries for date:', selectedDate);
 
       // Keine Filterung nach Typ mehr
-      const { data, error } = await getDailyEntries(undefined, selectedDate);
+      const { data, error } = await getCareEntries(selectedDate);
       if (error) {
         console.error('Error loading daily entries:', error);
       } else if (data) {
@@ -176,18 +176,25 @@ export default function DailyOldScreen() {
     end_time?: string;
     notes?: string;
     duration: number;
+    diaper_type?: 'wet' | 'poop' | 'both';
+    feeding_type?: 'breast' | 'bottle' | 'solid';
+    breast_side?: 'left' | 'right' | 'both';
+    bottle_amount?: number;
   }) => {
     try {
-      // Create a new entry with the current date
-      const newEntry: DailyEntry = {
+      const newEntry: CareEntry = {
         entry_date: selectedDate.toISOString(),
-        entry_type: entryData.entry_type,
+        entry_type: entryData.entry_type as 'feeding' | 'diaper',
         start_time: entryData.start_time,
         end_time: entryData.end_time,
-        notes: entryData.notes || ''
+        notes: entryData.notes || '',
+        diaper_type: entryData.diaper_type,
+        feeding_type: entryData.feeding_type,
+        breast_side: entryData.breast_side,
+        bottle_amount: entryData.bottle_amount
       };
 
-      const { error } = await saveDailyEntry(newEntry);
+      const { error } = await saveCareEntry(newEntry);
       if (error) {
         console.error('Error saving daily entry:', error);
         Alert.alert('Fehler', 'Der Eintrag konnte nicht gespeichert werden.');
@@ -219,7 +226,7 @@ export default function DailyOldScreen() {
             text: 'Löschen',
             style: 'destructive',
             onPress: async () => {
-              const { error } = await deleteDailyEntry(id);
+              const { error } = await deleteCareEntry(id);
               if (error) {
                 console.error('Error deleting daily entry:', error);
                 Alert.alert('Fehler', 'Der Eintrag konnte nicht gelöscht werden.');

--- a/components/ActivityCard.tsx
+++ b/components/ActivityCard.tsx
@@ -5,12 +5,12 @@ import { ThemedView } from '@/components/ThemedView';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { IconSymbol } from '@/components/ui/IconSymbol';
-import { DailyEntry } from '@/lib/baby';
+import { CareEntry } from '@/lib/care';
 import { Swipeable } from 'react-native-gesture-handler';
 import { LinearGradient } from 'expo-linear-gradient';
 
 interface ActivityCardProps {
-  entry: DailyEntry;
+  entry: CareEntry;
   onDelete: (id: string) => void;
 }
 

--- a/components/ActivityInputModal.tsx
+++ b/components/ActivityInputModal.tsx
@@ -28,6 +28,10 @@ interface ActivityInputModalProps {
     end_time?: string;
     notes?: string;
     duration: number;
+    diaper_type?: 'wet' | 'poop' | 'both';
+    feeding_type?: 'breast' | 'bottle' | 'solid';
+    breast_side?: 'left' | 'right' | 'both';
+    bottle_amount?: number;
   }) => void;
 }
 
@@ -45,6 +49,10 @@ const ActivityInputModal: React.FC<ActivityInputModalProps> = ({
   const [notes, setNotes] = useState('');
   const [showStartTimePicker, setShowStartTimePicker] = useState(false);
   const [showNotesField, setShowNotesField] = useState(false);
+  const [diaperType, setDiaperType] = useState<'wet' | 'poop' | 'both'>('wet');
+  const [feedingType, setFeedingType] = useState<'breast' | 'bottle' | 'solid'>('breast');
+  const [breastSide, setBreastSide] = useState<'left' | 'right' | 'both'>('both');
+  const [bottleAmount, setBottleAmount] = useState('');
 
   // Reset state when modal opens
   useEffect(() => {
@@ -54,6 +62,10 @@ const ActivityInputModal: React.FC<ActivityInputModalProps> = ({
       setEndTime(now); // Setze Ende gleich Start, da keine Dauer mehr benötigt wird
       setNotes('');
       setShowNotesField(false); // Reset notes field visibility
+      setDiaperType('wet');
+      setFeedingType('breast');
+      setBreastSide('both');
+      setBottleAmount('');
     }
   }, [visible]);
 
@@ -87,7 +99,11 @@ const ActivityInputModal: React.FC<ActivityInputModalProps> = ({
       start_time: startTime.toISOString(),
       end_time: endTime.toISOString(),
       notes: notes,
-      duration: 0 // Feste Dauer auf 0 setzen
+      duration: 0, // Feste Dauer auf 0 setzen
+      diaper_type: activityType === 'diaper' ? diaperType : undefined,
+      feeding_type: activityType === 'feeding' ? feedingType : undefined,
+      breast_side: activityType === 'feeding' && feedingType === 'breast' ? breastSide : undefined,
+      bottle_amount: activityType === 'feeding' && feedingType === 'bottle' ? parseInt(bottleAmount) || 0 : undefined
     });
     onClose();
   };
@@ -133,6 +149,71 @@ const ActivityInputModal: React.FC<ActivityInputModalProps> = ({
                   display="default"
                   onChange={handleStartTimeChange}
                 />
+              )}
+
+              {activityType === 'diaper' && (
+                <View style={styles.optionRow}>
+                  {(['wet','poop','both'] as const).map(type => (
+                    <TouchableOpacity
+                      key={type}
+                      style={[
+                        styles.optionButton,
+                        diaperType === type && styles.optionButtonActive
+                      ]}
+                      onPress={() => setDiaperType(type)}
+                    >
+                      <ThemedText>{type === 'wet' ? 'Nass' : type === 'poop' ? 'Voll' : 'Beides'}</ThemedText>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              )}
+
+              {activityType === 'feeding' && (
+                <>
+                  <View style={styles.optionRow}>
+                    {(['breast','bottle','solid'] as const).map(type => (
+                      <TouchableOpacity
+                        key={type}
+                        style={[
+                          styles.optionButton,
+                          feedingType === type && styles.optionButtonActive
+                        ]}
+                        onPress={() => setFeedingType(type)}
+                      >
+                        <ThemedText>
+                          {type === 'breast' ? 'Stillen' : type === 'bottle' ? 'Flasche' : 'Beikost'}
+                        </ThemedText>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+                  {feedingType === 'breast' && (
+                    <View style={styles.optionRow}>
+                      {(['left','right','both'] as const).map(side => (
+                        <TouchableOpacity
+                          key={side}
+                          style={[
+                            styles.optionButton,
+                            breastSide === side && styles.optionButtonActive
+                          ]}
+                          onPress={() => setBreastSide(side)}
+                        >
+                          <ThemedText>
+                            {side === 'left' ? 'Links' : side === 'right' ? 'Rechts' : 'Beides'}
+                          </ThemedText>
+                        </TouchableOpacity>
+                      ))}
+                    </View>
+                  )}
+                  {feedingType === 'bottle' && (
+                    <TextInput
+                      style={[styles.notesInput, { marginTop: 10 }]}
+                      value={bottleAmount}
+                      onChangeText={setBottleAmount}
+                      placeholder="Menge in ml"
+                      keyboardType="number-pad"
+                    />
+                  )}
+                </>
               )}
 
               {/* "Notiz hinzufügen" Button - nur anzeigen, wenn das Notizfeld nicht sichtbar ist */}
@@ -271,6 +352,22 @@ const styles = StyleSheet.create({
     fontSize: 16,
     marginLeft: 8,
     fontWeight: '500',
+  },
+  optionRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    marginVertical: 10,
+  },
+  optionButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderWidth: 1,
+    borderColor: '#CCCCCC',
+    borderRadius: 8,
+  },
+  optionButtonActive: {
+    backgroundColor: 'rgba(125,90,80,0.1)',
+    borderColor: '#7D5A50',
   },
 });
 

--- a/components/AnimatedTimelineView.tsx
+++ b/components/AnimatedTimelineView.tsx
@@ -15,18 +15,18 @@ import { ThemedView } from '@/components/ThemedView';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { IconSymbol } from '@/components/ui/IconSymbol';
-import { DailyEntry } from '@/lib/baby';
+import { CareEntry } from '@/lib/care';
 import { LinearGradient } from 'expo-linear-gradient';
 
 interface AnimatedTimelineViewProps {
-  entries: DailyEntry[];
+  entries: CareEntry[];
   onDeleteEntry?: (id: string) => void;
 }
 
 const AnimatedTimelineView: React.FC<AnimatedTimelineViewProps> = ({ entries, onDeleteEntry }) => {
   const colorScheme = useColorScheme() ?? 'light';
   const theme = Colors[colorScheme];
-  const [selectedEntry, setSelectedEntry] = useState<DailyEntry | null>(null);
+  const [selectedEntry, setSelectedEntry] = useState<CareEntry | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [timelineHeight, setTimelineHeight] = useState(0);
   const scrollViewRef = useRef<ScrollView>(null);

--- a/components/DailySummary.tsx
+++ b/components/DailySummary.tsx
@@ -5,10 +5,10 @@ import { ThemedView } from '@/components/ThemedView';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { IconSymbol } from '@/components/ui/IconSymbol';
-import { DailyEntry } from '@/lib/baby';
+import { CareEntry } from '@/lib/care';
 
 interface DailySummaryProps {
-  entries: DailyEntry[];
+  entries: CareEntry[];
 }
 
 const DailySummary: React.FC<DailySummaryProps> = ({ entries }) => {

--- a/components/TimelineView.tsx
+++ b/components/TimelineView.tsx
@@ -5,10 +5,10 @@ import { ThemedView } from '@/components/ThemedView';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { IconSymbol } from '@/components/ui/IconSymbol';
-import { DailyEntry } from '@/lib/baby';
+import { CareEntry } from '@/lib/care';
 
 interface TimelineViewProps {
-  entries: DailyEntry[];
+  entries: CareEntry[];
   onDeleteEntry: (id: string) => void;
   refreshControl?: React.ReactElement;
 }
@@ -24,7 +24,7 @@ const TimelineView: React.FC<TimelineViewProps> = ({ entries, onDeleteEntry, ref
   });
 
   // Gruppiere Einträge nach Stunden
-  const groupedEntries: Record<string, DailyEntry[]> = {};
+  const groupedEntries: Record<string, CareEntry[]> = {};
 
   sortedEntries.forEach(entry => {
     if (!entry.start_time) return;

--- a/lib/care.ts
+++ b/lib/care.ts
@@ -1,0 +1,87 @@
+import { supabase } from './supabase';
+
+export interface CareEntry {
+  id?: string;
+  user_id?: string;
+  entry_date: string;
+  entry_type: 'feeding' | 'diaper';
+  diaper_type?: 'wet' | 'poop' | 'both';
+  feeding_type?: 'breast' | 'bottle' | 'solid';
+  breast_side?: 'left' | 'right' | 'both';
+  bottle_amount?: number;
+  start_time: string;
+  end_time?: string;
+  notes?: string;
+}
+
+export const getCareEntries = async (date?: Date) => {
+  try {
+    const { data: userData } = await supabase.auth.getUser();
+    if (!userData.user) return { data: null, error: new Error('Nicht angemeldet') };
+
+    let query = supabase
+      .from('baby_care_entries')
+      .select('*')
+      .order('start_time', { ascending: false });
+
+    if (date) {
+      const start = new Date(date);
+      start.setHours(0,0,0,0);
+      const end = new Date(date);
+      end.setHours(23,59,59,999);
+      query = query.gte('entry_date', start.toISOString()).lte('entry_date', end.toISOString());
+    }
+
+    const { data, error } = await query;
+    return { data, error };
+  } catch (err) {
+    return { data: null, error: err };
+  }
+};
+
+export const saveCareEntry = async (entry: CareEntry) => {
+  try {
+    const { data: userData } = await supabase.auth.getUser();
+    if (!userData.user) return { data: null, error: new Error('Nicht angemeldet') };
+
+    if (entry.id) {
+      const { data, error } = await supabase
+        .from('baby_care_entries')
+        .update({ ...entry, updated_at: new Date().toISOString() })
+        .eq('id', entry.id)
+        .eq('user_id', userData.user.id)
+        .select()
+        .single();
+      return { data, error };
+    } else {
+      const { data, error } = await supabase
+        .from('baby_care_entries')
+        .insert({
+          user_id: userData.user.id,
+          ...entry,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString()
+        })
+        .select()
+        .single();
+      return { data, error };
+    }
+  } catch (err) {
+    return { data: null, error: err };
+  }
+};
+
+export const deleteCareEntry = async (id: string) => {
+  try {
+    const { data: userData } = await supabase.auth.getUser();
+    if (!userData.user) return { data: null, error: new Error('Nicht angemeldet') };
+    const { data, error } = await supabase
+      .from('baby_care_entries')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userData.user.id);
+    return { data, error };
+  } catch (err) {
+    return { data: null, error: err };
+  }
+};

--- a/supabase/migrations/20260701000000_create_baby_care_entries.sql
+++ b/supabase/migrations/20260701000000_create_baby_care_entries.sql
@@ -1,0 +1,62 @@
+-- Unified table for feeding and diaper activities
+CREATE TABLE IF NOT EXISTS public.baby_care_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  entry_date TIMESTAMPTZ NOT NULL,
+  entry_type TEXT CHECK (entry_type IN ('diaper','feeding')),
+  diaper_type TEXT CHECK (diaper_type IN ('wet','poop','both')),
+  feeding_type TEXT CHECK (feeding_type IN ('breast','bottle','solid')),
+  breast_side TEXT CHECK (breast_side IN ('left','right','both')),
+  bottle_amount INTEGER,
+  start_time TIMESTAMPTZ NOT NULL,
+  end_time TIMESTAMPTZ,
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  is_syncing BOOLEAN DEFAULT FALSE
+);
+
+-- trigger to keep updated_at current
+CREATE OR REPLACE FUNCTION public.update_baby_care_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER update_baby_care_entries_updated_at
+BEFORE UPDATE ON public.baby_care_entries
+FOR EACH ROW
+EXECUTE FUNCTION public.update_baby_care_updated_at();
+
+-- Row level security
+ALTER TABLE public.baby_care_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their own and linked care entries"
+ON public.baby_care_entries
+FOR SELECT
+USING (
+  auth.uid() = user_id OR
+  EXISTS (
+    SELECT 1 FROM public.account_links al
+    WHERE ((al.creator_id = auth.uid() AND al.invited_id = user_id) OR
+           (al.invited_id = auth.uid() AND al.creator_id = user_id))
+      AND al.status = 'accepted'
+  )
+);
+
+CREATE POLICY "Users can insert their own care entries"
+ON public.baby_care_entries
+FOR INSERT
+WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Users can update their own care entries"
+ON public.baby_care_entries
+FOR UPDATE
+USING (auth.uid() = user_id);
+
+CREATE POLICY "Users can delete their own care entries"
+ON public.baby_care_entries
+FOR DELETE
+USING (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- support new `baby_care_entries` table
- create helper functions for care entries
- extend `ActivityInputModal` for feeding/diaper details
- adjust daily screen and components to use new table
- add SQL migration for `baby_care_entries`

## Testing
- `npm install --silent`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688b0895f2848321848328c480ee6a05