### PR TITLE
Invert color scheme and theme cleanup

### DIFF
--- a/app/(tabs)/weight-tracker.tsx
+++ b/app/(tabs)/weight-tracker.tsx
@@ -16,6 +16,7 @@ import { saveWeightEntry, getWeightEntries, deleteWeightEntry, WeightEntry } fro
 export default function WeightTrackerScreen() {
   const colorScheme = useColorScheme() ?? 'light';
   const theme = Colors[colorScheme];
+  const styles = createStyles(theme);
   // router wird durch die BackButton-Komponente verwaltet
 
   const [weightEntries, setWeightEntries] = useState<WeightEntry[]>([]);
@@ -436,7 +437,8 @@ export default function WeightTrackerScreen() {
   );
 }
 
-const styles = StyleSheet.create({
+function createStyles(theme: typeof Colors.light) {
+  return StyleSheet.create({
   backgroundImage: {
     flex: 1,
     width: '100%',
@@ -615,7 +617,7 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
   input: {
-    backgroundColor: '#F5F5F5',
+    backgroundColor: theme.cardLight,
     borderRadius: 8,
     padding: 12,
     fontSize: 16,
@@ -628,7 +630,7 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    backgroundColor: '#F5F5F5',
+    backgroundColor: theme.cardLight,
     borderRadius: 8,
     padding: 12,
   },
@@ -639,7 +641,7 @@ const styles = StyleSheet.create({
     marginTop: 8,
   },
   saveButtonText: {
-    color: '#FFFFFF',
+    color: theme.textPrimary,
     fontSize: 16,
     fontWeight: 'bold',
   },
@@ -670,4 +672,5 @@ const styles = StyleSheet.create({
     fontSize: 14,
     textAlign: 'center',
   },
-});
+  });
+}

--- a/app/baby-size.tsx
+++ b/app/baby-size.tsx
@@ -25,6 +25,7 @@ function BabySizeContent() {
   const [babyData, setBabyData] = useState<BabySizeData | null>(null);
   const colorScheme = useColorScheme() ?? 'light';
   const theme = Colors[colorScheme];
+  const styles = createStyles(theme);
 
   useEffect(() => {
     // Finde die Daten für die aktuelle Woche
@@ -88,14 +89,14 @@ function BabySizeContent() {
                 <ThemedText style={styles.statLabel} lightColor="#888" darkColor={theme.textTertiary}>Größe</ThemedText>
                 <ThemedText style={styles.statValue}>{babyData.length}</ThemedText>
               </View>
-              <View style={[styles.statDivider, { backgroundColor: colorScheme === 'dark' ? theme.border : '#E0E0E0' }]} />
+              <View style={[styles.statDivider, { backgroundColor: theme.border }]} />
               <View style={styles.statItem}>
                 <ThemedText style={styles.statLabel} lightColor="#888" darkColor={theme.textTertiary}>Gewicht</ThemedText>
                 <ThemedText style={styles.statValue}>{babyData.weight}</ThemedText>
               </View>
             </View>
 
-            <View style={[styles.descriptionContainer, { borderTopColor: colorScheme === 'dark' ? theme.border : '#F0F0F0' }]}>
+            <View style={[styles.descriptionContainer, { borderTopColor: theme.border }]}>
               <ThemedText style={styles.descriptionTitle}>Entwicklung diese Woche</ThemedText>
               <ThemedText style={styles.descriptionText} lightColor="#444" darkColor={theme.textSecondary}>{babyData.description}</ThemedText>
             </View>
@@ -113,7 +114,7 @@ function BabySizeContent() {
                   key={data.week}
                   style={[
                     styles.weekButton,
-                    { backgroundColor: colorScheme === 'dark' ? theme.cardDark : '#F5F5F5' },
+                    { backgroundColor: colorScheme === 'dark' ? theme.cardDark : theme.cardLight },
                     data.week === babyData.week && styles.selectedWeekButton
                   ]}
                   onPress={() => router.setParams({ week: data.week.toString() })}
@@ -136,7 +137,8 @@ function BabySizeContent() {
   );
 }
 
-const styles = StyleSheet.create({
+function createStyles(theme: typeof Colors.light) {
+  return StyleSheet.create({
   backgroundImage: {
     flex: 1,
     width: '100%',
@@ -222,7 +224,7 @@ const styles = StyleSheet.create({
   },
   statDivider: {
     width: 1,
-    backgroundColor: '#E0E0E0',
+    backgroundColor: theme.border,
     marginHorizontal: 16,
   },
   statLabel: {
@@ -236,7 +238,7 @@ const styles = StyleSheet.create({
   descriptionContainer: {
     paddingTop: 16,
     borderTopWidth: 1,
-    borderTopColor: '#F0F0F0',
+    borderTopColor: theme.border,
   },
   descriptionTitle: {
     fontSize: 16,
@@ -283,4 +285,5 @@ const styles = StyleSheet.create({
   selectedWeekButtonText: {
     color: 'white',
   },
-});
+  });
+}

--- a/hooks/useColorScheme.ts
+++ b/hooks/useColorScheme.ts
@@ -5,5 +5,13 @@ import { useTheme } from '@/contexts/ThemeContext';
 // und fällt auf das System-Farbschema zurück, wenn keine Einstellung vorhanden ist.
 export function useColorScheme() {
   const { colorScheme } = useTheme();
-  return colorScheme as 'light' | 'dark';
+  // Invert the color scheme so that the app renders dark when the user selects
+  // light mode and vice versa. Default to 'light' when no scheme is available.
+  if (colorScheme === 'light') {
+    return 'dark';
+  }
+  if (colorScheme === 'dark') {
+    return 'light';
+  }
+  return 'light';
 }

--- a/hooks/useColorScheme.web.ts
+++ b/hooks/useColorScheme.web.ts
@@ -14,8 +14,17 @@ export function useColorScheme() {
   const colorScheme = useRNColorScheme();
 
   if (hasHydrated) {
-    return colorScheme;
+    // Swap the detected color scheme so light mode users see the dark theme and
+    // vice versa.
+    if (colorScheme === 'light') {
+      return 'dark';
+    }
+    if (colorScheme === 'dark') {
+      return 'light';
+    }
+    return 'light';
   }
 
-  return 'light';
+  // Default to the inverted light theme before hydration.
+  return 'dark';
 }


### PR DESCRIPTION
## Summary
- invert the color scheme in `useColorScheme` hooks so selecting light shows dark and vice versa
- generate themed styles for weight tracker and baby size pages
- replace hard-coded colors with theme values

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688c6be480c483219c22972f2a571fa2